### PR TITLE
Backward Compability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-./output
-./conda
-*.mp4
+output
+conda
 experiments
+validation_data
+*.mp4
 .*

--- a/sw/rocsync/board_profiles.py
+++ b/sw/rocsync/board_profiles.py
@@ -1,0 +1,155 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+from rocsync.vision import CameraType
+
+def _mm2px(mm, board_mm, board_size):
+    return mm / board_mm * board_size
+
+
+@dataclass(frozen=True)
+class BoardProfile:
+    name: str
+    board_size: int                   # rectified image dimension (px)
+    board_mm: float                   # physical board size (mm)
+    aruco_marker_id: int
+    period: int
+    visible_radius: int
+    ir_radius: int
+    corner_dots: np.ndarray           # RGB corner LED positions in rectified image (px)
+    ir_corners: np.ndarray            # IR corner positions for perspective transform (px, always 4)
+    aruco_corners_coords: np.ndarray  # ArUco destination corners in rectified image (px, always 4)
+    perspective_corner_slice: slice   # which corner_dots subset for the 4-point transform
+    counter_led_coords: dict          # {CameraType: np.ndarray Nx2 int} LED positions (px)
+    counter_bg_y: dict                # {CameraType: int} background sample y-coordinate (px)
+    counter_bits: int
+
+    def __hash__(self):
+        return hash(self.name)
+
+
+def _build_v1(board_size=640, board_mm=250):
+    mm2px = lambda mm: _mm2px(mm, board_mm, board_size)
+
+    corner_dots = np.array([
+        [51, 51],
+        [board_size - 52, 51],
+        [board_size - 52, board_size - 52],
+        [51, board_size - 52],
+    ], dtype=np.float32)
+
+    ir_corners = np.array([
+        [13, 13],
+        [board_size - 14, 13],
+        [board_size - 14, board_size - 13],
+        [13, board_size - 14],
+    ], dtype=np.float32)
+
+    aruco_corners_coords = np.array([
+        [202, 202],
+        [board_size - 203, 202],
+        [board_size - 203, board_size - 203],
+        [202, board_size - 203],
+    ], dtype=np.float32)
+
+    # Counter: 16 LEDs in a single row, x = (65 + i*8) mm
+    n_leds = 16
+    x_coords = np.array([int(mm2px(65 + i * 8)) for i in range(n_leds)])
+    rgb_y = int(mm2px(53))
+    ir_y = int(mm2px(48))
+
+    rgb_leds = np.stack([x_coords, np.full(n_leds, rgb_y)], axis=1)
+    ir_leds = np.stack([x_coords, np.full(n_leds, ir_y)], axis=1)
+
+    # Background sampled at y - 25 px in original code
+    rgb_bg_y = rgb_y - 25
+    ir_bg_y = ir_y - 25
+
+    return BoardProfile(
+        name="v1",
+        board_size=board_size,
+        board_mm=board_mm,
+        aruco_marker_id=0,
+        period=100,
+        visible_radius=294,
+        ir_radius=280,
+        corner_dots=corner_dots,
+        ir_corners=ir_corners,
+        aruco_corners_coords=aruco_corners_coords,
+        perspective_corner_slice=slice(None),
+        counter_led_coords={CameraType.RGB: rgb_leds, CameraType.INFRARED: ir_leds},
+        counter_bg_y={CameraType.RGB: rgb_bg_y, CameraType.INFRARED: ir_bg_y},
+        counter_bits=16,
+    )
+
+
+def _build_v2(board_size=640, board_mm=250):
+    mm2px = lambda mm: _mm2px(mm, board_mm, board_size)
+
+    corner_dots = np.array([
+        [13, 51],   # 5th additional RGB LED
+        [51, 51],
+        [board_size - 52, 51],
+        [board_size - 52, board_size - 52],
+        [51, board_size - 52],
+    ], dtype=np.float32)
+
+    # 4 standard corners for IR perspective transform
+    # (v2 has a 5th IR LED at [51, 13] but it is not used for the transform)
+    ir_corners = np.array([
+        [13, 13],
+        [board_size - 14, 13],
+        [board_size - 14, board_size - 13],
+        [13, board_size - 14],
+    ], dtype=np.float32)
+
+    aruco_corners_coords = np.array([
+        [202, 202],
+        [board_size - 203, 202],
+        [board_size - 203, board_size - 203],
+        [202, board_size - 203],
+    ], dtype=np.float32)
+
+    # Counter: 20 LEDs in 2 rows x 10, x from 71mm to 179mm
+    n_per_row = 10
+    x_coords = np.linspace(mm2px(71), mm2px(179), n_per_row).astype(int)
+    rgb_y1 = round(mm2px(41))
+    rgb_y2 = round(mm2px(53))
+    ir_y1 = round(mm2px(47))
+    ir_y2 = round(mm2px(59))
+
+    rgb_leds = np.stack([
+        np.tile(x_coords, 2),
+        np.concatenate([np.full(n_per_row, rgb_y1), np.full(n_per_row, rgb_y2)]),
+    ], axis=1)
+    ir_leds = np.stack([
+        np.tile(x_coords, 2),
+        np.concatenate([np.full(n_per_row, ir_y1), np.full(n_per_row, ir_y2)]),
+    ], axis=1)
+
+    bg_y = round(mm2px(34))
+
+    return BoardProfile(
+        name="v2",
+        board_size=board_size,
+        board_mm=board_mm,
+        aruco_marker_id=21,
+        period=100,
+        visible_radius=294,
+        ir_radius=280,
+        corner_dots=corner_dots,
+        ir_corners=ir_corners,
+        aruco_corners_coords=aruco_corners_coords,
+        perspective_corner_slice=slice(1, None),
+        counter_led_coords={CameraType.RGB: rgb_leds, CameraType.INFRARED: ir_leds},
+        counter_bg_y={CameraType.RGB: bg_y, CameraType.INFRARED: bg_y},
+        counter_bits=20,
+    )
+
+
+BOARD_V1 = _build_v1()
+BOARD_V2 = _build_v2()
+ALL_PROFILES = [BOARD_V1, BOARD_V2]
+PROFILES_BY_NAME = {p.name: p for p in ALL_PROFILES}
+PROFILES_BY_ARUCO = {p.aruco_marker_id: p for p in ALL_PROFILES}

--- a/sw/rocsync/main.py
+++ b/sw/rocsync/main.py
@@ -8,6 +8,7 @@ import cv2
 import numpy as np
 from tqdm import tqdm
 
+from rocsync.board_profiles import PROFILES_BY_NAME
 from rocsync.printer import errprint, succprint, warnprint
 from rocsync.video import process_video
 from rocsync.vision import CameraType, process_frame
@@ -26,9 +27,9 @@ class NpEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
-def process_image(path, camera_type, debug_dir=None):
+def process_image(path, camera_type, debug_dir=None, board=None):
     image = cv2.imread(path)
-    _, timestamp = process_frame(image, camera_type, 0, debug_dir)
+    _, timestamp = process_frame(image, camera_type, 0, board, debug_dir)
     if timestamp is not None:
         succprint(f"start: {timestamp[0]} ms, end {timestamp[1]} ms")
         return {"start": timestamp[0], "end": timestamp[1]}
@@ -123,6 +124,12 @@ def main():
         metavar="DIRECTORY",
         help="directory to store debug images (very slow)",
     )
+    parser.add_argument(
+        "--board-version",
+        choices=["auto"] + list(PROFILES_BY_NAME.keys()),
+        default="auto",
+        help="board hardware revision (default: auto-detect from ArUco marker ID)",
+    )
 
     # Specify time windows to search for ROCsync
     parser.add_argument(
@@ -156,6 +163,8 @@ def main():
     )
 
     args = parser.parse_args()
+
+    board = PROFILES_BY_NAME.get(args.board_version) if args.board_version != "auto" else None
 
     # Parse time arguments
     start_time1, end_time1 = parse_time(args.start1), parse_time(args.end1)
@@ -241,13 +250,14 @@ def main():
                 end_time1,
                 start_time2,
                 end_time2,
+                board=board,
             )
             if ret is not None:
                 result[str(file)] = ret.to_dict()
             else:
                 errprint(f"Error: Unable to time-sync {file}.")
         elif file in images:
-            ret = process_image(file, CameraType(args.camera_type), debug_dir)
+            ret = process_image(file, CameraType(args.camera_type), debug_dir, board)
             if ret is not None:
                 result[str(file)] = ret
             else:

--- a/sw/rocsync/video.py
+++ b/sw/rocsync/video.py
@@ -60,9 +60,7 @@ def export_frames(video_path, output_path, y_pred):
     with ThreadPoolExecutor(max_workers=100) as executor:
         futures = []
         for _ in range(n_frames):
-            futures.append(
-                executor.submit(export_frame_async, frame_queue, y_pred, output_path)
-            )
+            futures.append(executor.submit(export_frame_async, frame_queue, y_pred, output_path))
         for future in tqdm(
             as_completed(futures), total=n_frames, desc="Exporting frames", position=1
         ):
@@ -70,29 +68,17 @@ def export_frames(video_path, output_path, y_pred):
     cap.release()
 
 
-def process_video_window(
-    video_path: str,
-    camera_type: CameraType,
-    window_start: int,
-    window_end: int,
-    stride=None,
-    debug_dir: str = None,
-    brightness_boost: int = None,
-):
+def process_video_window(video_path: str, camera_type: CameraType, window_start: int, window_end: int, stride=None, debug_dir: str = None, brightness_boost: int = None, board=None):
     cap = cv2.VideoCapture(video_path)
 
     # Extract video metadata
     fps = cap.get(cv2.CAP_PROP_FPS)
     start_frame = int(max(0, math.floor(window_start * fps)))
-    end_frame = int(
-        min(math.ceil(window_end * fps) + 1, cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    )  # end_frame is exclusive
+    end_frame = int(min(math.ceil(window_end * fps) + 1, cap.get(cv2.CAP_PROP_FRAME_COUNT))) # end_frame is exclusive
 
     # Read frames in separate thread
     frame_queue = queue.Queue(maxsize=100)
-    thread = threading.Thread(
-        target=read_frames_async, args=(cap, frame_queue, start_frame, end_frame)
-    )
+    thread = threading.Thread(target=read_frames_async, args=(cap, frame_queue, start_frame, end_frame))
     thread.daemon = False
     thread.start()
 
@@ -100,50 +86,30 @@ def process_video_window(
     scan_window = 0
     if stride is None:
         stride = int(fps)
-
-    pbar = tqdm(
-        range(start_frame, end_frame),
-        desc=f"Analyzing frames in time window [{window_start:.3f}s, {window_end:.3f}s] --> Found {len(timestamps)} timestamps",
-        position=1,
-    )
+    
+    pbar = tqdm(range(start_frame, end_frame), desc=f"Analyzing frames in time window [{window_start:.3f}s, {window_end:.3f}s] --> Found {len(timestamps)} timestamps", position=1)
     for _ in pbar:
         frame, frame_number = frame_queue.get()  # blocking wait
         if frame is None:
-            errprint(
-                "Error: Input stream ended unexpectedly. Could be a sign of skipped frames."
-            )
+            errprint("Error: Input stream ended unexpectedly. Could be a sign of skipped frames.")
             break
         if scan_window > 0 or frame_number % stride == 0:
-            rocsync_detected, timestamp = process_frame(
-                frame, camera_type, frame_number, debug_dir, brightness_boost
-            )
+            rocsync_detected, timestamp = process_frame(frame, camera_type, frame_number, board, debug_dir, brightness_boost)
             scan_window -= 1
             if timestamp is not None:
                 timestamps[frame_number] = timestamp
             if rocsync_detected:
                 scan_window = 5
-                pbar.set_description(
-                    f"Analyzing frames in time window [{window_start:.3f}s, {window_end:.3f}s] --> Found {len(timestamps)} timestamps"
-                )
+                pbar.set_description(f"Analyzing frames in time window [{window_start:.3f}s, {window_end:.3f}s] --> Found {len(timestamps)} timestamps")
+
 
     thread.join()
     cap.release()
-
+            
     return timestamps
 
 
-def process_video(
-    video_path,
-    camera_type,
-    export_dir=None,
-    stride=None,
-    debug_dir=None,
-    window1_start=None,
-    window1_end=None,
-    window2_start=None,
-    window2_end=None,
-    brightness_boost=None,
-):
+def process_video(video_path, camera_type, export_dir=None, stride=None, debug_dir=None, window1_start=None, window1_end=None, window2_start=None, window2_end=None, brightness_boost=None, board=None):
     # Get video metadata
     cap = cv2.VideoCapture(video_path, cv2.CAP_FFMPEG)
     # cap.set(cv2.CAP_PROP_FFMPEG_HWACCEL, cv2.CAP_FFMPEG_HWACCEL_NVDEC)  # try to use
@@ -178,30 +144,13 @@ def process_video(
         window2_end = max(0, (expected_duration / 1000) + window2_end)
 
     # Analyze frames
-    timestamps = process_video_window(
-        video_path,
-        camera_type,
-        window1_start,
-        window1_end,
-        stride,
-        debug_dir,
-        brightness_boost,
-    )
+    timestamps = process_video_window(video_path, camera_type, window1_start, window1_end, stride, debug_dir, brightness_boost, board)
 
-    if (
-        window2_start > window1_end or window2_end < window1_start
-    ):  # check if window2 is not overlapping with window1
+    if window2_start > window1_end or window2_end < window1_start: # check if window2 is not overlapping with window1
         # TODO: better window checking
-        timestamps2 = process_video_window(
-            video_path,
-            camera_type,
-            window2_start,
-            window2_end,
-            stride,
-            debug_dir,
-            brightness_boost,
-        )
+        timestamps2 = process_video_window(video_path, camera_type, window2_start, window2_end, stride, debug_dir, brightness_boost, board)
         timestamps = {**timestamps, **timestamps2}
+    
 
     if len(timestamps) < 2:
         errprint("Error: Insufficient number of timestamped frames.")
@@ -219,9 +168,7 @@ def process_video(
 
     # Assert that we have at least 80% inliers
     if np.sum(model.inlier_mask_) < 0.8 * len(timestamps):
-        warnprint(
-            f"WARNING: Estimated model has fewer than 80% inliers ({np.sum(model.inlier_mask_) / len(timestamps):.2%})."
-        )
+        warnprint(f"WARNING: Estimated model has fewer than 80% inliers ({np.sum(model.inlier_mask_) / len(timestamps):.2%}).")
 
     # Predict timestamps for all frames
     x_range = np.arange(0, n_frames).reshape(-1, 1)
@@ -275,13 +222,7 @@ def process_video(
 
     if debug_dir:
         plot_timechart(
-            filtered_x,
-            filtered_y,
-            x_range,
-            y_pred,
-            exposure_times,
-            expected_duration,
-            debug_dir,
+            filtered_x, filtered_y, x_range, y_pred, exposure_times, expected_duration, debug_dir
         )
         plot_exposure_histogram(exposure_times, debug_dir)
 
@@ -315,8 +256,8 @@ def print_statistics(statistics: VideoStatistics):
         f"{statistics.rmse_before:.2f}/{statistics.rmse_after:.2f} ms",
         statistics.rmse_after < 2,
     )
-    print(format_str.format("First frame:", f"{statistics.first_frame / 1000:.3f} s"))
-    print(format_str.format("Last frame:", f"{statistics.last_frame / 1000:.3f} s"))
+    print(format_str.format("First frame:", f"{statistics.first_frame/1000:.3f} s"))
+    print(format_str.format("Last frame:", f"{statistics.last_frame/1000:.3f} s"))
     print(
         format_str.format(
             "Framerate (expected/measured):",
@@ -326,7 +267,7 @@ def print_statistics(statistics: VideoStatistics):
     print(
         format_str.format(
             "Duration (expected/measured):",
-            f"{statistics.expected_duration / 1000:.3f}/{statistics.measured_duration / 1000:.3f} s (Δ={statistics.measured_duration - statistics.expected_duration:.2f} ms)",
+            f"{statistics.expected_duration/1000:.3f}/{statistics.measured_duration/1000:.3f} s (Δ={statistics.measured_duration-statistics.expected_duration:.2f} ms)",
         )
     )
     print(

--- a/sw/rocsync/vision.py
+++ b/sw/rocsync/vision.py
@@ -4,7 +4,7 @@ from enum import Enum
 import cv2
 import numpy as np
 
-# from rocsync.printer import *
+from rocsync.printer import *
 
 
 class CameraType(Enum):
@@ -31,48 +31,7 @@ parameters = cv2.aruco.DetectorParameters()
 parameters.cornerRefinementMethod = cv2.aruco.CORNER_REFINE_NONE
 aruco_detector = cv2.aruco.ArucoDetector(dictionary, parameters)
 
-# Board layout
-frquency = 1000
-aruco_marker_id = 21
-board_size = 640
-period = 100
 led_size = 8
-ir_radius = 280
-visible_radius = 294
-
-# NOTE: not yet teste: IR decoding with new led
-ir_corners = np.array(
-    [
-        [13, 13],
-        [51, 13],  # 5th additional IR led
-        [board_size - 14, 13],
-        [board_size - 14, board_size - 13],
-        [13, board_size - 14],
-    ],
-    dtype=np.float32,
-)
-
-# NOTE: decoding with new RGB led works (tested)
-corner_dots = np.array(
-    [
-        [13, 51],  # 5th additional red led
-        [51, 51],
-        [board_size - 52, 51],
-        [board_size - 52, board_size - 52],
-        [51, board_size - 52],
-    ],
-    dtype=np.float32,
-)
-
-aruco_corners_coords = np.array(
-    [
-        [202, 202],
-        [board_size - 203, 202],
-        [board_size - 203, board_size - 203],
-        [202, board_size - 203],
-    ],
-    dtype=np.float32,
-)
 
 
 def draw_polygon(points, image, color):
@@ -95,26 +54,26 @@ def read_led(img, x, y):
 
 def find_optimal_ring_start_end(leds):
     """
-    Find the most likely window of leds turned ON, while allowing for false detections.
-    Computes the window [start, end) that maximizes the sum of values within the window minus the sum of values outside,
-    while allowing for wrap-around windows. True is treated as 1 and False as -1.
+        Find the most likely window of leds turned ON, while allowing for false detections.
+        Computes the window [start, end) that maximizes the sum of values within the window minus the sum of values outside,
+        while allowing for wrap-around windows. True is treated as 1 and False as -1.
 
-    Args:
-        leds: A list of booleans indicating the detected led state.
+        Args:
+            leds: A list of booleans indicating the detected led state.
 
-    Returns:
-        A tuple containing:
-        - A tuple of [start, end) indices for the optimal window.
-          If start > end, the window wraps around.
-          If start == end, the window is empty.
-        - The maximum possible score.
-    """
+        Returns:
+            A tuple containing:
+            - A tuple of [start, end) indices for the optimal window.
+              If start > end, the window wraps around.
+              If start == end, the window is empty.
+            - The maximum possible score.
+        """
     nums = [1 if val else -1 for val in leds]
     n = len(nums)
     total_sum = sum(nums)
 
     # --- Find max non-wrapping subarray and its indices (Kadane's Algorithm) ---
-    max_score = -float("inf")
+    max_score = -float('inf')
     max_start, max_end = 0, 0
     current_max = 0
     current_start_max = 0
@@ -131,7 +90,7 @@ def find_optimal_ring_start_end(leds):
             max_end = i + 1
 
     # --- Find min non-wrapping subarray and its indices ---
-    min_score = float("inf")
+    min_score = float('inf')
     min_start, min_end = 0, 0
     current_min = 0
     current_start_min = 0
@@ -148,7 +107,7 @@ def find_optimal_ring_start_end(leds):
             min_end = i + 1
 
     # --- Determine the optimal window and score, now considering the empty set ---
-    max_wrap_sum = -float("inf")
+    max_wrap_sum = -float('inf')
     if n > 1:  # A wrapping window needs at least 2 elements
         max_wrap_sum = total_sum - min_score
 
@@ -174,8 +133,10 @@ def find_optimal_ring_start_end(leds):
     return final_window, final_score
 
 
-def read_ring(extracted_board, camera_type, draw_result=False):
-    radius = visible_radius if camera_type == CameraType.RGB else ir_radius
+def read_ring(extracted_board, camera_type, board, draw_result=False):
+    radius = board.visible_radius if camera_type == CameraType.RGB else board.ir_radius
+    board_size = board.board_size
+    period = board.period
 
     # Collect mean LED intensities relative to local background
     led_intensities = np.zeros(period, dtype=np.uint8)
@@ -193,9 +154,7 @@ def read_ring(extracted_board, camera_type, draw_result=False):
         led_intensities[i] = np.clip(led_intensity - bg_intensity, 0, 255)
 
     # Apply Otsu's thresholding to led_intensities
-    _, otsu_thresh = cv2.threshold(
-        led_intensities, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
-    )
+    _, otsu_thresh = cv2.threshold(led_intensities, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
     leds = otsu_thresh.astype(bool).flatten().tolist()
 
     # Find most likely segment of enabled LEDs, allowing for false detections
@@ -216,74 +175,25 @@ def read_ring(extracted_board, camera_type, draw_result=False):
     return start, (end - 1) % period
 
 
-def read_counter(extracted_board, camera_type, draw_result=False):
-
-    # board total length [mm]
-    l_board = 250
-    # resolution of the image (should be taken from argument I guess) [px]
-    res = 640
-    # IR rows y coordinate [mm]
-    IR_yR1 = 47
-    IR_yR2 = 59
-    # RGB rows y coordinate [mm]
-    RGB_yR1 = 41
-    RGB_yR2 = 53
-    # x limits for all rows [mm]
-    x0 = 71
-    x1 = 179
-    # y coordinates for where the background intensity is sampled [mm]
-    # TODO: check that this location doesn't have light bleed from neighbouring leds!
-    yBG = 34
-    # number of leds per row
-    Nx = 10
-    # total number of leds
-    Ntot = 20
-
-    def _mm2px(mm: float, l_board=l_board, res=res):
-        return (mm / l_board) * res
-
-    # 2d array with all led coords [n, (x, y)]
-    led_coords = np.stack(
-        [
-            # x coordinates: range of x values for the 2 rows repeated
-            np.tile(np.linspace(_mm2px(x0), _mm2px(x1), Nx), 2),
-            # y coordinates: first all yR1, second all yR2
-            np.concat(
-                [
-                    np.array(
-                        Nx
-                        * [_mm2px(RGB_yR1 if camera_type == CameraType.RGB else IR_yR1)]
-                    ),
-                    np.array(
-                        Nx
-                        * [_mm2px(RGB_yR2 if camera_type == CameraType.RGB else IR_yR2)]
-                    ),
-                ],
-                axis=0,
-            ),
-        ],
-        axis=1,
-    )
-    led_coords = np.round(led_coords, decimals=0).astype(int)
+def read_counter(extracted_board, camera_type, board, draw_result=False):
+    led_coords = board.counter_led_coords[camera_type]
+    bg_y = board.counter_bg_y[camera_type]
+    n_bits = board.counter_bits
 
     # Collect mean LED intensities relative to local background
     led_intensities = np.zeros(led_coords.shape[0], dtype=np.uint8)
     for i, (x, y) in enumerate(led_coords):
         led_intensity = read_led(extracted_board, x, y)
-        bg_intensity = read_led(
-            extracted_board, x, round(_mm2px(yBG))
-        )  # TODO fix bg location
+        bg_intensity = read_led(extracted_board, x, bg_y)
         led_intensities[i] = np.clip(led_intensity - bg_intensity, 0, 255)
 
     # Apply Otsu's thresholding to led_intensities
-    _, otsu_thresh = cv2.threshold(
-        led_intensities, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
-    )
+    _, otsu_thresh = cv2.threshold(led_intensities, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
     leds = otsu_thresh.astype(bool)
 
     # convert binary table to time value
-    potrange = np.arange(0, Ntot, 1)[::-1]
-    counter = np.sum(2 ** potrange[leds.squeeze()])
+    potrange = np.arange(0, n_bits, 1)[::-1]
+    counter = np.sum(2**potrange[leds.squeeze()])
 
     # draw optional debug output
     if draw_result:
@@ -293,7 +203,7 @@ def read_counter(extracted_board, camera_type, draw_result=False):
                 (x, y),
                 led_size,
                 (0, 0, 255) if state else (255, 0, 0),
-                1,
+                1
             )
 
     return counter
@@ -340,7 +250,8 @@ def find_corners_convexhull(mask, frame_number, debug_dir=None):
         return corners
 
 
-def find_corners_dots(mask, frame_number, debug_dir=None):
+def find_corners_dots(mask, frame_number, board, debug_dir=None):
+    corner_dots = board.corner_dots
     points = blob_detector.detect(mask)
     if not points:
         return
@@ -355,14 +266,10 @@ def find_corners_dots(mask, frame_number, debug_dir=None):
         cv2.imwrite(f"{debug_dir}/corner_{frame_number}.png", debug_image)
 
     closest_points = [
-        min(points, key=lambda p: np.linalg.norm(p.pt - target)).pt
-        for target in corner_dots
+        min(points, key=lambda p: np.linalg.norm(p.pt - target)).pt for target in corner_dots
     ]
-    max_distance = max(
-        [np.linalg.norm(act - exp) for act, exp in zip(closest_points, corner_dots)]
-    )
+    max_distance = max([np.linalg.norm(act - exp) for act, exp in zip(closest_points, corner_dots)])
     if max_distance > 50:
-        # print(f"Rejected {frame_number}: corner LED was {max_distance} px from where it should be")
         return  # Some corner is too far away from where it should be
 
     return np.array(closest_points, dtype=np.float32)
@@ -379,97 +286,91 @@ def find_corners_aruco(mask, frame_number, debug_dir=None, brightness_boost=None
         cv2.imwrite(f"{debug_dir}/aruco_{frame_number}.png", debug_image)
 
     if marker_ids is None:
-        return
-    marker_dict = {id[0]: marker for id, marker in zip(marker_ids, markers)}
-    if aruco_marker_id in marker_dict.keys():
-        return marker_dict[aruco_marker_id]
+        return {}
+    return {id[0]: marker for id, marker in zip(marker_ids, markers)}
 
 
-def process_frame(
-    image, camera_type, frame_number, debug_dir=None, brightness_boost=None
-):
+def process_frame(image, camera_type, frame_number, board=None, debug_dir=None, brightness_boost=None):
+    from rocsync.board_profiles import PROFILES_BY_ARUCO
 
     match camera_type:
         case CameraType.RGB:
-            # First extract course PCB using ArUco marker
-            aruco_corners = find_corners_aruco(
-                image, frame_number, debug_dir, brightness_boost
-            )
-            if aruco_corners is None:
+            # Detect ArUco markers
+            markers = find_corners_aruco(image, frame_number, debug_dir, brightness_boost)
+            if not markers:
                 return False, None
 
-            # Check if aruco marker fills x % of the image to make sure the PCB was held close enough
-            # area = 0
-            # for i in range(4):
-            #    x1, y1 = aruco_corners[0][i]
-            #    x2, y2 = aruco_corners[0][(i + 1) % 4]  # Wrap around to the first point
-            #    area += (x1 * y2) - (y1 * x2)
-            # area = abs(area) / 2
-            # height, width = image.shape[:2]
-            # image_area = width * height
-            # area_percentage = area/image_area
-            # if area_percentage < 0.002:
-            #    print(f"Rejected {frame_number}: aruco marker only fills {area_percentage} of the image")
-            #    return False, None
+            # Resolve board profile
+            if board is None:
+                for marker_id, corners in markers.items():
+                    if marker_id in PROFILES_BY_ARUCO:
+                        board = PROFILES_BY_ARUCO[marker_id]
+                        aruco_corners = corners
+                        break
+                else:
+                    return False, None
+            else:
+                if board.aruco_marker_id not in markers:
+                    return False, None
+                aruco_corners = markers[board.aruco_marker_id]
+
+            board_size = board.board_size
 
             red_channel = image[:, :, 2]
-            # _, mask = cv2.threshold(red_channel, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
-            # mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
             mask = red_channel
 
-            # Use course PCB to accurately extract corner
+            # Use coarse PCB to accurately extract corners
             rough_transformation_matrix = cv2.getPerspectiveTransform(
-                aruco_corners, aruco_corners_coords
+                aruco_corners, board.aruco_corners_coords
             )
             rough_pcb = cv2.warpPerspective(
                 mask, rough_transformation_matrix, (board_size, board_size)
             )
-            # cv2.imwrite(f"{debug_dir}/rough_pcb_{frame_number}.png", rough_pcb)
-            corners = find_corners_dots(rough_pcb, frame_number, debug_dir)
+            corners = find_corners_dots(rough_pcb, frame_number, board, debug_dir)
             if corners is None:
                 return True, None
 
-            # NOTE: only four points are needed/allowed to calculate the perspective transform. removing the one that doesn't for a perfect square.
+            s = board.perspective_corner_slice
             transformation_matrix = np.dot(
-                cv2.getPerspectiveTransform(corners[1:, :], corner_dots[1:, :]),
+                cv2.getPerspectiveTransform(corners[s], board.corner_dots[s]),
                 rough_transformation_matrix,
             )
-            pcb = cv2.warpPerspective(
-                mask, transformation_matrix, (board_size, board_size)
-            )
-            # cv2.imwrite(f"{debug_dir}/rectified_pcb_{frame_number}.png", pcb)
+            pcb = cv2.warpPerspective(mask, transformation_matrix, (board_size, board_size))
+
         case CameraType.INFRARED:
+            if board is None:
+                raise ValueError("IR mode requires an explicit board version (--board-version)")
+
+            board_size = board.board_size
+
             gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-            _, mask = cv2.threshold(
-                gray_image, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
-            )
+            _, mask = cv2.threshold(gray_image, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
             mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
             corners = find_corners_convexhull(mask, frame_number, debug_dir)
             if corners is None:
                 return False, None
-            transformation_matrix = cv2.getPerspectiveTransform(corners, ir_corners)
-            pcb = cv2.warpPerspective(
-                mask, transformation_matrix, (board_size, board_size)
-            )
+            transformation_matrix = cv2.getPerspectiveTransform(corners, board.ir_corners)
+            pcb = cv2.warpPerspective(mask, transformation_matrix, (board_size, board_size))
 
             # Find correct rotation
             for _ in range(4):
-                if read_counter(pcb, CameraType.INFRARED) == 0:
+                if read_counter(pcb, CameraType.INFRARED, board) == 0:
                     pcb = cv2.rotate(pcb, cv2.ROTATE_90_CLOCKWISE)
-            if read_counter(pcb, CameraType.INFRARED) == 0:
+            if read_counter(pcb, CameraType.INFRARED, board) == 0:
                 return True, None  # Counter was actually 0, can't determine orientation
 
     if debug_dir:  # For RGB debug output
         pcb = cv2.cvtColor(pcb, cv2.COLOR_GRAY2BGR)
 
-    counter = read_counter(pcb, camera_type, draw_result=True)
-    ring = read_ring(pcb, camera_type, draw_result=True)
+    counter = read_counter(pcb, camera_type, board, draw_result=True)
+    ring = read_ring(pcb, camera_type, board, draw_result=True)
 
     if debug_dir:
         cv2.imwrite(f"{debug_dir}/leds_{frame_number}.png", pcb)
 
     if ring is not None:
         start, end = ring
+        period = board.period
         if start > end or start <= 1 or period - end <= 1:
             return True, None  # Counter increment during exposure
 

--- a/sw/tests/unittest_process_frame.py
+++ b/sw/tests/unittest_process_frame.py
@@ -7,34 +7,35 @@ sys.path.insert(0, os.path.normcase(Path(__file__).resolve().parents[1]))
 import cv2 as cv
 import matplotlib.pyplot as plt
 import numpy as np
+from rocsync.board_profiles import BOARD_V2
 from rocsync.vision import (
     CameraType,
-    aruco_corners_coords,
-    board_size,
-    corner_dots,
     find_corners_aruco,
     find_corners_dots,
-    ir_corners,
     process_frame,
     read_counter,
     read_ring,
 )
 
-
 def test_piecewise():
-    """test the individual elements of the process_frame function with the new led layout"""
+    """ test the individual elements of the process_frame function with the new led layout """
 
+    board = BOARD_V2
+    board_size = board.board_size
     TEST_DIR = Path(__file__).resolve().parents[0]
 
     # prepare the pcb ----------------------------------------------------------
-    image = cv.imread(TEST_DIR / "img1.jpg")
+    image = cv.imread(TEST_DIR/"img1.jpg")
 
-    aruco_corners = find_corners_aruco(
-        image, frame_number=999, debug_dir=TEST_DIR / "output_piecewise"
+    markers = find_corners_aruco(
+        image,
+        frame_number=999,
+        debug_dir=TEST_DIR/"output_piecewise"
     )
+    aruco_corners = markers[board.aruco_marker_id]
     red_channel = image[:, :, 2]
     rough_transformation_matrix = cv.getPerspectiveTransform(
-        aruco_corners, aruco_corners_coords
+        aruco_corners, board.aruco_corners_coords
     )
     rough_pcb = cv.warpPerspective(
         red_channel, rough_transformation_matrix, (board_size, board_size)
@@ -42,25 +43,29 @@ def test_piecewise():
     cv.imwrite(TEST_DIR / "output_piecewise" / "rough_pcb.jpg", rough_pcb)
 
     # still works, additional led is just ignored with the original 4 points. Add the 5th red one just to be safe
-    corners = find_corners_dots(rough_pcb, 999, debug_dir=TEST_DIR / "output_piecewise")
+    corners = find_corners_dots(
+        rough_pcb,
+        999,
+        board,
+        debug_dir=TEST_DIR/"output_piecewise"
+    )
 
     # however, this only works with exactly 4 points
+    s = board.perspective_corner_slice
     transformation_matrix = np.dot(
-        cv.getPerspectiveTransform(corners[1:, :], corner_dots[1:, :]),
+        cv.getPerspectiveTransform(corners[s], board.corner_dots[s]),
         rough_transformation_matrix,
     )
-    pcb = cv.warpPerspective(
-        red_channel, transformation_matrix, (board_size, board_size)
-    )
+    pcb = cv.warpPerspective(red_channel, transformation_matrix, (board_size, board_size))
 
-    cv.imwrite(TEST_DIR / "output_piecewise" / "pcb.jpg", pcb)
+    cv.imwrite(TEST_DIR/"output_piecewise"/"pcb.jpg", pcb)
 
     # decode the ring (should remain the same) ---------------------------------
-    ring = read_ring(pcb, camera_type=CameraType.RGB, draw_result=True)
+    ring = read_ring(pcb, camera_type=CameraType.RGB, board=board, draw_result=True)
     print(f"ring decoded: {ring}")
 
     # decode clock (must be adjusted to new layout) ----------------------------
-    counter = read_counter(pcb, camera_type=CameraType.RGB, draw_result=True)
+    counter = read_counter(pcb, camera_type=CameraType.RGB, board=board, draw_result=True)
     print(f"decoded clock: {counter} [0.1s]")
 
     # show the debug image output
@@ -80,7 +85,8 @@ def test_full():
         image,
         camera_type=CameraType.RGB,
         frame_number=999,
-        debug_dir=TEST_DIR / "output_full",
+        board=BOARD_V2,
+        debug_dir=TEST_DIR/"output_full"
     )
     print(f"output of process frame was: {out}")
 


### PR DESCRIPTION
PR to add backwards compatibility to ROCSync revision 1 boards.

Summary of changes:
- Introduced a BoardProfile class which contains the specifics and layout of the ROCSync board revisions.
- Introduced --board-version flag to let the user select a specific board version, or AUTO mode in which the board version is determined from the detected arUco marker id
- Generalized all methods in vision to decode the board-specific components correctly

I only tested this PR on two test images so far (one for revision 1, one for revision 2), so some additional testing could be useful to ensure we do not introduce any new edge cases or bugs.

should fix #5 